### PR TITLE
Updated debian packages to use jessie debian version (current stable)

### DIFF
--- a/uml/rootfs/multistrap.conf.in
+++ b/uml/rootfs/multistrap.conf.in
@@ -11,7 +11,7 @@ setupscript=./build-scripts/before-dpkg-setup.sh
 packages=makedev locales build-essential g++ nano procps xvfb iproute net-tools iputils-ping curl wget rsync libxrender-dev libxtst-dev check pkg-config valgrind libxslt-dev libxml2-dev libreadline6 libreadline6-dev curl git-core zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev libgdbm-dev ncurses-dev automake libtool bison subversion libffi-dev openssl libxrender-dev libxtst-dev xmlstarlet
 source=http://ftp.fi.debian.org/debian
 keyring=debian-archive-keyring
-suite=squeeze
+suite=jessie
 
 [Updates]
 packages=


### PR DESCRIPTION
from squeeze (current oldoldstable)

This was initiated by some courses requiring more recent version of gcc.