### PR TITLE
Fix dnsmasq download URL

### DIFF
--- a/misc/Makefile
+++ b/misc/Makefile
@@ -13,7 +13,7 @@ dummy_create_work_dir := $(shell test -d $(WORK) || mkdir -p $(WORK))
 DNSMASQ_VERSION=2.67
 SQUID_VERSION=3.5.21
 
-DNSMASQ_URL=http://www.thekelleys.org.uk/dnsmasq/dnsmasq-$(DNSMASQ_VERSION).tar.gz
+DNSMASQ_URL=http://www.thekelleys.org.uk/dnsmasq/archive/dnsmasq-$(DNSMASQ_VERSION).tar.gz
 SQUID_URL=http://www.squid-cache.org/Versions/v3/3.5/squid-$(SQUID_VERSION).tar.gz
 
 DNSMASQ_DIR=$(WORK)/dnsmasq-$(DNSMASQ_VERSION)


### PR DESCRIPTION
The current build script fails due to a 404 error when downloading dnsmasq sources.

The dnsmasq version used by the sandbox is old enough to have been moved to the archive, so the URL needs to be updated accordingly.